### PR TITLE
Fix showing request status insertion

### DIFF
--- a/src/hooks/usePropertyRequest.tsx
+++ b/src/hooks/usePropertyRequest.tsx
@@ -112,14 +112,16 @@ export const usePropertyRequest = () => {
       const estimatedDate = new Date();
       estimatedDate.setDate(estimatedDate.getDate() + 2);
 
-      // Create showing requests for each property with new status system
+      // Create showing requests for each property.
+      // Use the legacy "pending" status since the database check constraint
+      // currently only allows this value.
       const requests = propertiesToSubmit.map(property => ({
         user_id: user.id,
         property_address: property,
         preferred_date: preferredDate || null,
         preferred_time: preferredTime || null,
         message: formData.notes || null,
-        status: 'submitted', // Use new status instead of 'pending'
+        status: 'pending',
         estimated_confirmation_date: estimatedDate.toISOString().split('T')[0] // YYYY-MM-DD format
       }));
 


### PR DESCRIPTION
## Summary
- fix status on new showing requests to use `pending`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6841ba27002c8326a628df0a259537f2