### PR TITLE
Refactor ProblemSolutionSection and auth

### DIFF
--- a/src/components/ProblemSolutionSection.tsx
+++ b/src/components/ProblemSolutionSection.tsx
@@ -1,23 +1,7 @@
 
+import { problemPoints } from "@/data/problemPoints";
+
 const ProblemSolutionSection = () => {
-  const problemPoints = [
-    {
-      problem: "Traditional agents pressure you into exclusive buyer agreements before showing a single home, trapping you with someone you may not want to work with",
-      solution: "Tour homes with vetted professionals without any contracts or commitments - decide if you want representation after experiencing the service firsthand"
-    },
-    {
-      problem: "You're stuck with weekend-only open houses on the seller's schedule, fighting crowds and getting rushed through properties you're serious about",
-      solution: "Schedule private showings 7 days a week at times that work for YOUR schedule - evenings, mornings, or weekends with undivided attention"
-    },
-    {
-      problem: "Agents often show you homes that benefit their commission rather than your needs, and you have no way to know their true motivations",
-      solution: "Your showing partner has no hidden agenda - they're paid fairly regardless of which home you choose, so their focus is entirely on helping you find the right fit"
-    },
-    {
-      problem: "The new NAR rules create confusion about who pays what and when, leaving buyers uncertain about costs until it's too late to back out",
-      solution: "Complete transparency from day one: first showing is free, additional services have clear flat-rate pricing with no surprise fees or commission splits"
-    }
-  ];
 
   return (
     <div className="py-20 bg-gradient-to-br from-slate-50 via-purple-50 to-blue-50">

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -3,6 +3,7 @@ import { createContext, useContext, useEffect, useState } from 'react';
 import { User, Session } from '@supabase/supabase-js';
 import type { AuthError } from '@supabase/auth-js';
 import { supabase } from '@/integrations/supabase/client';
+import * as authService from '@/services/authService';
 
 interface AuthContextType {
   user: User | null;
@@ -61,50 +62,20 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     email: string,
     password: string,
     metadata: Record<string, unknown>
-  ) => {
-    const { error } = await supabase.auth.signUp({
-      email,
-      password,
-      options: {
-        emailRedirectTo: `${window.location.origin}/buyer-dashboard`,
-        data: metadata
-      }
-    });
-    
-    return { error };
-  };
+  ) => authService.signUp(email, password, metadata);
 
   const signIn = async (
     email: string,
     password: string
-  ) => {
-    const { error } = await supabase.auth.signInWithPassword({
-      email,
-      password
-    });
-    
-    return { error };
-  };
+  ) => authService.signIn(email, password);
 
   const signInWithProvider = async (
     provider: 'google' | 'facebook',
     userType: 'buyer' | 'agent'
-  ) => {
-    const { error } = await supabase.auth.signInWithOAuth({
-      provider,
-      options: {
-        redirectTo: `${window.location.origin}/buyer-dashboard`,
-        queryParams: {
-          user_type: userType
-        }
-      }
-    });
-    
-    return { error };
-  };
+  ) => authService.signInWithProvider(provider, userType);
 
   const signOut = async () => {
-    await supabase.auth.signOut();
+    await authService.signOut();
   };
 
   return (

--- a/src/data/problemPoints.ts
+++ b/src/data/problemPoints.ts
@@ -1,0 +1,23 @@
+export interface ProblemPoint {
+  problem: string;
+  solution: string;
+}
+
+export const problemPoints: ProblemPoint[] = [
+  {
+    problem: "Traditional agents pressure you into exclusive buyer agreements before showing a single home, trapping you with someone you may not want to work with",
+    solution: "Tour homes with vetted professionals without any contracts or commitments - decide if you want representation after experiencing the service firsthand"
+  },
+  {
+    problem: "You're stuck with weekend-only open houses on the seller's schedule, fighting crowds and getting rushed through properties you're serious about",
+    solution: "Schedule private showings 7 days a week at times that work for YOUR schedule - evenings, mornings, or weekends with undivided attention"
+  },
+  {
+    problem: "Agents often show you homes that benefit their commission rather than your needs, and you have no way to know their true motivations",
+    solution: "Your showing partner has no hidden agenda - they're paid fairly regardless of which home you choose, so their focus is entirely on helping you find the right fit"
+  },
+  {
+    problem: "The new NAR rules create confusion about who pays what and when, leaving buyers uncertain about costs until it's too late to back out",
+    solution: "Complete transparency from day one: first showing is free, additional services have clear flat-rate pricing with no surprise fees or commission splits"
+  }
+];

--- a/src/hooks/useAuthForm.tsx
+++ b/src/hooks/useAuthForm.tsx
@@ -1,6 +1,6 @@
 
 import { useState } from "react";
-import { useToast } from "@/hooks/use-toast";
+import { useToastHelper } from "@/utils/toastUtils";
 import { useAuth } from "@/contexts/AuthContext";
 
 interface AuthFormData {
@@ -21,7 +21,7 @@ export const useAuthForm = (userType: 'buyer' | 'agent', onSuccess: () => void) 
     licenseNumber: ''
   });
   const [isLoading, setIsLoading] = useState(false);
-  const { toast } = useToast();
+  const toastHelper = useToastHelper();
   const { signUp, signIn, signInWithProvider } = useAuth();
 
   const handleSocialLogin = async (provider: 'google' | 'facebook') => {
@@ -29,24 +29,16 @@ export const useAuthForm = (userType: 'buyer' | 'agent', onSuccess: () => void) 
     try {
       const { error } = await signInWithProvider(provider, userType);
       if (error) {
-        toast({
-          title: "Social Login Error",
-          description: error.message,
-          variant: "destructive"
-        });
+        toastHelper.error("Social Login Error", error.message);
       } else {
-        toast({
-          title: "Success!",
-          description: `Signed in with ${provider === 'google' ? 'Google' : 'Facebook'}!`,
-        });
+        toastHelper.success(
+          "Success!",
+          `Signed in with ${provider === 'google' ? 'Google' : 'Facebook'}!`
+        );
         onSuccess();
       }
     } catch (error) {
-      toast({
-        title: "Error",
-        description: "Something went wrong with social login",
-        variant: "destructive"
-      });
+      toastHelper.error("Error", "Something went wrong with social login");
     } finally {
       setIsLoading(false);
     }
@@ -64,16 +56,9 @@ export const useAuthForm = (userType: 'buyer' | 'agent', onSuccess: () => void) 
       if (isLogin) {
         const { error } = await signIn(formData.email, formData.password);
         if (error) {
-          toast({
-            title: "Error",
-            description: error.message,
-            variant: "destructive"
-          });
+          toastHelper.error("Error", error.message);
         } else {
-          toast({
-            title: "Success!",
-            description: "Welcome back!",
-          });
+          toastHelper.success("Success!", "Welcome back!");
           onSuccess();
           if (userType === 'buyer') {
             window.location.href = '/buyer-dashboard';
@@ -93,16 +78,12 @@ export const useAuthForm = (userType: 'buyer' | 'agent', onSuccess: () => void) 
 
         const { error } = await signUp(formData.email, password, metadata);
         if (error) {
-          toast({
-            title: "Error",
-            description: error.message,
-            variant: "destructive"
-          });
+          toastHelper.error("Error", error.message);
         } else {
-          toast({
-            title: "Success!",
-            description: "Account created successfully! Please check your email to verify your account.",
-          });
+          toastHelper.success(
+            "Success!",
+            "Account created successfully! Please check your email to verify your account."
+          );
           // Switch to login mode after successful signup
           setIsLogin(true);
         }

--- a/src/hooks/usePropertyRequest.tsx
+++ b/src/hooks/usePropertyRequest.tsx
@@ -7,7 +7,8 @@ import { supabase } from "@/integrations/supabase/client";
 
 const convertTo24Hour = (time: string): string => {
   const [t, modifier] = time.split(' ');
-  let [hours, minutes] = t.split(':');
+  let hours = t.split(':')[0];
+  const minutes = t.split(':')[1];
   if (modifier.toLowerCase() === 'pm' && hours !== '12') {
     hours = String(Number(hours) + 12);
   }

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -1,0 +1,46 @@
+import { supabase } from "@/integrations/supabase/client";
+import type { AuthError } from "@supabase/auth-js";
+
+export const signUp = async (
+  email: string,
+  password: string,
+  metadata: Record<string, unknown>
+): Promise<{ error: AuthError | null }> => {
+  const { error } = await supabase.auth.signUp({
+    email,
+    password,
+    options: {
+      emailRedirectTo: `${window.location.origin}/buyer-dashboard`,
+      data: metadata
+    }
+  });
+
+  return { error };
+};
+
+export const signIn = async (
+  email: string,
+  password: string
+): Promise<{ error: AuthError | null }> => {
+  const { error } = await supabase.auth.signInWithPassword({ email, password });
+  return { error };
+};
+
+export const signInWithProvider = async (
+  provider: 'google' | 'facebook',
+  userType: 'buyer' | 'agent'
+): Promise<{ error: AuthError | null }> => {
+  const { error } = await supabase.auth.signInWithOAuth({
+    provider,
+    options: {
+      redirectTo: `${window.location.origin}/buyer-dashboard`,
+      queryParams: { user_type: userType }
+    }
+  });
+
+  return { error };
+};
+
+export const signOut = async () => {
+  await supabase.auth.signOut();
+};


### PR DESCRIPTION
## Summary
- extract static buyer problems to dedicated data file
- centralize Supabase auth logic in `authService`
- unify toast handling with `useToastHelper`
- fix lint error in `usePropertyRequest`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6841e39e836c83269504da9b4186e7fa