### PR TITLE
Fix Google sign-in redirect

### DIFF
--- a/src/services/authService.test.ts
+++ b/src/services/authService.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: {
+    auth: {
+      signInWithOAuth: vi.fn()
+    }
+  }
+}));
+
+import { signInWithProvider } from './authService';
+import { supabase } from '@/integrations/supabase/client';
+
+const oauthMock = supabase.auth.signInWithOAuth as vi.Mock;
+
+interface GlobalWithWindow {
+  window: { location: { href: string } };
+}
+const globalWithWindow = global as unknown as GlobalWithWindow;
+
+beforeEach(() => {
+  oauthMock.mockReset();
+  globalWithWindow.window = { location: { href: '' } };
+});
+
+describe('signInWithProvider', () => {
+  it('redirects when OAuth returns a URL', async () => {
+    oauthMock.mockResolvedValue({ data: { url: 'https://example.com' }, error: null });
+    const result = await signInWithProvider('google', 'buyer');
+    expect(result.error).toBeNull();
+    expect(globalWithWindow.window.location.href).toBe('https://example.com');
+  });
+
+  it('does not redirect if no URL is returned', async () => {
+    oauthMock.mockResolvedValue({ data: null, error: null });
+    const result = await signInWithProvider('google', 'buyer');
+    expect(result.error).toBeNull();
+    expect(globalWithWindow.window.location.href).toBe('');
+  });
+});

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -30,13 +30,17 @@ export const signInWithProvider = async (
   provider: 'google' | 'facebook',
   userType: 'buyer' | 'agent'
 ): Promise<{ error: AuthError | null }> => {
-  const { error } = await supabase.auth.signInWithOAuth({
+  const { data, error } = await supabase.auth.signInWithOAuth({
     provider,
     options: {
       redirectTo: `${window.location.origin}/buyer-dashboard`,
       queryParams: { user_type: userType }
     }
   });
+
+  if (data?.url) {
+    window.location.href = data.url;
+  }
 
   return { error };
 };


### PR DESCRIPTION
## Summary
- ensure OAuth sign-in redirects users to the provider
- add tests for signInWithProvider

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6841e7c180f08326a59ec78b43620e33