### PR TITLE
Add basic blog feature with initial posts

### DIFF
--- a/seo-blog-roadmap.md
+++ b/seo-blog-roadmap.md
@@ -1,0 +1,102 @@
+# SEO Blog Roadmap for FirstLook
+
+## 1. Define the Strategy
+
+**Goal:** Capture organic traffic from early-stage real estate buyers through informational, intent-driven content
+
+**Audience:**
+- First-time homebuyers
+- Move-up buyers
+- Millennial/Gen Z DIY buyers
+- Sellers curious about alternatives to agents
+
+**Tone & Voice:**
+- Friendly but authoritative
+- Empowering and transparent
+- Tech-forward, modern real estate feel
+- Avoids "traditional realtor speak"
+
+**Top SEO Goals:**
+- Rank for long-tail, buyer-intent keywords
+- Build topical authority around "agentless home buying"
+- Drive traffic to your subscription/tour flow
+- Educate → Build trust → Convert
+
+## 2. Build Topic Clusters
+
+Each cluster targets a core concept, with interlinked posts. Here’s a suggested architecture:
+
+### Cluster 1: Touring Homes Without an Agent
+- How to see homes without hiring a realtor
+- What is a showing agent? (And how it’s different)
+- Can I tour a home before I have a real estate agent?
+- What to expect during a FirstLook home tour
+- On-demand home tours: Are they safe and legit?
+
+### Cluster 2: First-Time Buyer Education
+- Step-by-step: How to buy a home with no agent
+- What’s included in a home tour—and what to look for
+- How to compare homes after a tour
+- What to do after seeing a home you love
+
+### Cluster 3: Transparency in Real Estate
+- Why most homebuyers feel pressured into choosing an agent
+- Hidden costs of traditional real estate you should know
+- How FirstLook is different from a buyer’s agent
+- Your options after touring a home: full breakdown
+
+### Cluster 4: Real Estate Pricing & Fees
+- Is $499 a good price for offer writing?
+- What’s a fair cost to get help with real estate paperwork?
+- Homebuying fees decoded: from tours to closing costs
+
+### Cluster 5: Modern Buying Journey
+- Why Millennial buyers want to skip the agent
+- Buying a house on your terms in the digital age
+- How technology is reshaping real estate in 2025
+
+## 3. SEO Setup & Execution Plan
+
+### Keyword Research Tools
+- Google Search Console (once live)
+- Ahrefs / Ubersuggest / Keywords Everywhere
+- Use long-tail queries, e.g.:
+  - "can i tour a house without a realtor"
+  - "home tour without agent 2025"
+  - "best way to buy a house without a real estate agent"
+
+### Post Format Template
+
+Each post should include:
+- Catchy, search-optimized title
+- First 100 words = problem + preview + CTA
+- Clear subheadings (H2s) for structure
+- Internal links to FirstLook features or related posts
+- CTA to try FirstLook ("Tour a home now, no commitment")
+
+## 4. Foundational Posts (Write These First)
+1. Can I Tour a Home Without an Agent? (Yes, Here’s How)
+2. Homebuying Without a Realtor: A Step-by-Step Guide
+3. What to Expect from a FirstLook Tour
+4. After the Tour: What Are My Options?
+5. The Case for Commitment-Free Home Shopping
+
+These anchor articles can be 1,200–1,800 words and should be optimized for both users and search engines.
+
+## 5. Publishing Cadence & Growth
+- **Initial Launch Plan:** 5 core posts + About + Contact
+- **Ongoing Cadence:** 1 blog/week minimum
+- **Shareable Formats:** Convert blog content into:
+  - Email drips
+  - Instagram carousels
+  - TikTok or Reels
+  - LinkedIn posts about agentless buying trends
+
+## 6. Tracking & Optimization
+- Install Google Analytics & Search Console
+- Track:
+  - Organic traffic growth
+  - Bounce rates on blog pages
+  - Clicks to tour/signup pages
+- Use heatmaps (e.g., Hotjar) to see scroll/click behavior
+- Reoptimize high-potential posts every 3–6 months

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,3 @@
-
 import { Toaster } from "@/components/ui/toaster";
 import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -19,6 +18,7 @@ import NotFound from "./pages/NotFound";
 import BuyerAuth from "./pages/BuyerAuth";
 import AgentAuth from "./pages/AgentAuth";
 import Blog from "./pages/Blog";
+import BlogPost from "./pages/BlogPost";
 
 const queryClient = new QueryClient();
 
@@ -40,6 +40,7 @@ const App = () => (
               <Route path="/agent-dashboard" element={<AgentDashboard />} />
               <Route path="/subscriptions" element={<Subscriptions />} />
               <Route path="/blog" element={<Blog />} />
+              <Route path="/blog/:slug" element={<BlogPost />} />
               <Route path="/single-home-tour" element={<SingleHomeTour />} />
               <Route path="/tour-session" element={<TourSession />} />
               <Route path="/buyer-auth" element={<BuyerAuth />} />

--- a/src/data/blogPosts.ts
+++ b/src/data/blogPosts.ts
@@ -1,0 +1,68 @@
+export interface BlogPost {
+  slug: string;
+  title: string;
+  date: string;
+  excerpt: string;
+  category: string;
+  content: string[];
+}
+
+export const blogPosts: BlogPost[] = [
+  {
+    slug: "tour-home-without-agent",
+    title: "Can I Tour a Home Without an Agent? (Yes, Here\u2019s How)",
+    date: "2025-06-05",
+    excerpt:
+      "Learn the exact steps to schedule a private tour without signing up with a traditional real estate agent.",
+    category: "Touring Homes Without an Agent",
+    content: [
+      "Thinking about touring a property but not ready to commit to an agent? FirstLook lets you book showings on your schedule with vetted local professionals. No contracts, no pressure. Here\u2019s how it works:",
+      "1. Create a free FirstLook account and choose the home you\u2019d like to see.\n2. We match you with a licensed showing partner.\n3. Pick a time that works for you.\n4. Tour the property privately and ask all your burning questions.",
+      "After your first free showing, decide whether you want additional help or walk away, no strings attached.",
+    ],
+  },
+  {
+    slug: "homebuying-without-realtor",
+    title: "Homebuying Without a Realtor: A Step-by-Step Guide",
+    date: "2025-06-05",
+    excerpt:
+      "A transparent roadmap for purchasing a home on your own terms using modern tools and on-demand support.",
+    category: "First-Time Buyer Education",
+    content: [
+      "Buying a home without a dedicated buyer\u2019s agent is completely possible if you know the process. This guide outlines every major milestone from searching to closing. You\u2019ll learn how to line up financing, evaluate properties, make competitive offers, and bring in professional help only where you need it.",
+    ],
+  },
+  {
+    slug: "what-to-expect-firstlook-tour",
+    title: "What to Expect from a FirstLook Tour",
+    date: "2025-06-05",
+    excerpt:
+      "Get the inside scoop on what happens during your on-demand showing so you can arrive prepared and confident.",
+    category: "Touring Homes Without an Agent",
+    content: [
+      "From the moment you request a tour to the follow-up afterwards, this article walks you through the entire experience. See how our showing partners verify access, share local insights, and give you space to explore without sales tactics. We\u2019ll also cover safety protocols and how to capture notes so you can compare homes later.",
+    ],
+  },
+  {
+    slug: "after-the-tour-options",
+    title: "After the Tour: What Are My Options?",
+    date: "2025-06-05",
+    excerpt:
+      "Not sure what to do once you\u2019ve found a home you love? We break down the choices so you stay in control.",
+    category: "Transparency in Real Estate",
+    content: [
+      "Maybe the home is perfect, or perhaps you have more questions. Either way, you decide the next step. Continue touring, request offer-writing help for a flat fee, or connect with a full-service agent if you prefer. This post covers the pros and cons of each path so you can move forward with clarity.",
+    ],
+  },
+  {
+    slug: "commitment-free-home-shopping",
+    title: "The Case for Commitment-Free Home Shopping",
+    date: "2025-06-05",
+    excerpt:
+      "Traditional brokerage agreements can feel overwhelming. Discover why more buyers choose flexibility first.",
+    category: "Modern Buying Journey",
+    content: [
+      "Home shopping has changed in the digital age. With so much information online, you deserve the freedom to explore properties before choosing representation. We examine the rise of on-demand touring services like FirstLook and how they empower buyers to stay in the driver\u2019s seat while still getting expert guidance when it matters most.",
+    ],
+  },
+];

--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -1,7 +1,33 @@
+import { Link } from "react-router-dom";
+import { blogPosts } from "@/data/blogPosts";
 
 const Blog = () => (
-  <div className="min-h-screen flex items-center justify-center">
-    <h1 className="text-xl font-semibold">Blog coming soon</h1>
+  <div className="min-h-screen bg-white py-10">
+    <div className="container mx-auto px-4 max-w-4xl">
+      <h1 className="text-4xl font-bold mb-8">FirstLook Blog</h1>
+      <div className="space-y-8">
+        {blogPosts.map((post) => (
+          <div key={post.slug} className="border-b pb-6">
+            <h2 className="text-2xl font-semibold mb-2">
+              <Link
+                to={`/blog/${post.slug}`}
+                className="text-purple-700 hover:underline"
+              >
+                {post.title}
+              </Link>
+            </h2>
+            <p className="text-gray-500 text-sm mb-2">{post.date}</p>
+            <p className="text-gray-700 mb-2">{post.excerpt}</p>
+            <Link
+              to={`/blog/${post.slug}`}
+              className="text-purple-600 font-medium hover:underline"
+            >
+              Read More
+            </Link>
+          </div>
+        ))}
+      </div>
+    </div>
   </div>
 );
 

--- a/src/pages/BlogPost.tsx
+++ b/src/pages/BlogPost.tsx
@@ -1,0 +1,41 @@
+import { Link, useParams } from "react-router-dom";
+import { blogPosts } from "@/data/blogPosts";
+import { ArrowLeft } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+const BlogPost = () => {
+  const { slug } = useParams<{ slug: string }>();
+  const post = blogPosts.find((p) => p.slug === slug);
+
+  if (!post) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <p>Post not found.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-white py-10">
+      <div className="container mx-auto px-4 max-w-3xl">
+        <Link to="/blog">
+          <Button variant="ghost" className="mb-6">
+            <ArrowLeft className="w-4 h-4 mr-2" /> Back to Blog
+          </Button>
+        </Link>
+
+        <article>
+          <h1 className="text-4xl font-bold mb-2">{post.title}</h1>
+          <p className="text-gray-500 mb-8">{post.date}</p>
+          {post.content.map((paragraph, index) => (
+            <p key={index} className="mb-4 text-gray-700 leading-relaxed">
+              {paragraph}
+            </p>
+          ))}
+        </article>
+      </div>
+    </div>
+  );
+};
+
+export default BlogPost;


### PR DESCRIPTION
## Summary
- implement simple blog list and post pages
- add initial content per SEO roadmap
- enable routing for blog posts

## Testing
- `bun install`
- `npm run lint` *(warn: Fast refresh only works when a file only exports components)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6841ec1676408326a951d5480e37625c