### PR TITLE
Add blog post on agent help and fix vitest

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test": "vitest run"
+    "test": "npx vitest run"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",

--- a/src/data/blogPosts.ts
+++ b/src/data/blogPosts.ts
@@ -65,4 +65,28 @@ export const blogPosts: BlogPost[] = [
       "Home shopping has changed in the digital age. With so much information online, you deserve the freedom to explore properties before choosing representation. We examine the rise of on-demand touring services like FirstLook and how they empower buyers to stay in the driver\u2019s seat while still getting expert guidance when it matters most.",
     ],
   },
+  {
+    slug: "agent-or-not-professional-help",
+    title: "Agent or Not? When to Get Professional Help in the Process",
+    date: "2025-06-05",
+    excerpt:
+      "Wondering when to get a real estate agent? Learn when professional help makes sense\u2014and when you can buy a home without one.",
+    category: "First-Time Buyer Education",
+    content: [
+      "One of the most common questions buyers ask is: when should I get a real estate agent? With so many tools available today, it's easier than ever to browse, tour, and even make offers on homes without traditional representation. Still, there are moments in the buying journey where professional guidance can be invaluable. This post breaks down when you actually need a real estate agent\u2014and when you might be just fine without one.",
+      "Buyers, especially younger ones, are increasingly tech-savvy and self-reliant. Here\u2019s why many start their journey solo:",
+      "- Autonomy: Buyers want to browse, tour, and research without being pressured into early decisions.\n- Transparency: Traditional agent commissions can feel opaque\u2014especially when you\u2019re not sure what services you\u2019re getting.\n- Availability of Tools: Sites like Zillow, Redfin, and FirstLook make it easy to find and view homes on your own schedule.",
+      "Skipping an agent early on doesn\u2019t mean going it alone forever\u2014it means starting on your terms.",
+      "There are points in the process where a professional adds value, even if you began the journey independently:",
+      "1. You\u2019ve Found \u201cThe One\u201d \u2013 You\u2019re ready to make an offer and want to negotiate strategically. A skilled buyer\u2019s agent can help you navigate pricing, contingencies, and closing timelines.\n2. You\u2019re New to the Market \u2013 If you\u2019re unfamiliar with local trends, school districts, or zoning laws, an agent can help you avoid costly mistakes.\n3. You\u2019re Buying a Complex Property \u2013 Multifamily homes, co-ops, or fixer-uppers may come with red tape. An agent can spot hidden issues or alert you to financing challenges.\n4. The Seller Has an Agent \u2013 If you\u2019re negotiating with a listing agent, it helps to have someone equally experienced advocating for your interests.",
+      "There are plenty of stages where having a full-time agent isn\u2019t necessary:",
+      "- Browsing Listings: Public search platforms often have the same data agents use.\n- Touring Homes: Platforms like FirstLook allow buyers to schedule showings without committing to an agent.\n- Evaluating Fit: You\u2019re still figuring out what you want\u2014and don\u2019t want sales pressure while you decide.\n- Running Numbers: You can use online mortgage calculators, budget tools, and inspection guides before involving a pro.",
+      "In these early phases, the cost-to-value ratio of hiring an agent may be low\u2014especially if you're not yet offer-ready.",
+      "You don\u2019t have to choose between \u201cfull agent\u201d or \u201cno help at all.\u201d Today\u2019s homebuyer has more flexible options:",
+      "- Flat-Fee Services: Need help writing an offer or managing paperwork? Services like FirstLook offer one-time support (e.g., $499/offer or $249 for closing docs).\n- A la Carte Support: Some brokerages now let you pay for only what you use\u2014pricing out by task instead of commission percentage.\n- Tour-Only Agents: Want help unlocking a door or answering questions on-site? You can book agent assistance without giving up control of your buying process.",
+      "These models empower you to get the right help at the right time\u2014and avoid overspending on services you don\u2019t need.",
+      "You don\u2019t need a real estate agent to start your homebuying journey\u2014but that doesn\u2019t mean you should go it alone forever. Start independently if it fits your style, and bring in help when the stakes rise. Whether you\u2019re making an offer or navigating a tricky transaction, having access to flexible support is key.",
+      "Want the best of both worlds? With FirstLook, you can browse, tour, and get help only when you need it\u2014no contracts, no pressure.",
+    ],
+  },
 ];


### PR DESCRIPTION
## Summary
- add a blog entry explaining when to seek professional real estate help
- call `vitest` through `npx` so tests run without a global install

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842183e685c8326abf71df19f2a1b64