### PR TITLE
Add SQL migration for admin workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,19 @@ npm test
 
 Vitest will execute the test suite defined under `src/`. If you encounter a "cannot find package 'vitest'" error, ensure dependencies are installed.
 
+## Database migrations
+
+SQL files used to keep the Supabase schema in sync live under `supabase/sql`.
+To apply the latest changes for the admin workflow run:
+
+```sh
+supabase db execute < supabase/sql/20250605_admin_workflow.sql
+```
+
+This adds columns for agent assignment and status tracking on the
+`showing_requests` table and installs a trigger to update
+`status_updated_at` whenever the status changes.
+
 ## Can I connect a custom domain to my Lovable project?
 
 Yes, you can!

--- a/supabase/sql/20250605_admin_workflow.sql
+++ b/supabase/sql/20250605_admin_workflow.sql
@@ -1,0 +1,27 @@
+-- Migration to support admin workflow
+-- Adds assigned agent fields and status tracking to showing_requests.
+
+ALTER TABLE showing_requests
+  ADD COLUMN IF NOT EXISTS assigned_agent_id uuid REFERENCES profiles(id),
+  ADD COLUMN IF NOT EXISTS assigned_agent_name text,
+  ADD COLUMN IF NOT EXISTS assigned_agent_phone text,
+  ADD COLUMN IF NOT EXISTS assigned_agent_email text,
+  ADD COLUMN IF NOT EXISTS estimated_confirmation_date date,
+  ADD COLUMN IF NOT EXISTS internal_notes text,
+  ADD COLUMN IF NOT EXISTS status_updated_at timestamptz;
+
+CREATE OR REPLACE FUNCTION set_status_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF NEW.status IS DISTINCT FROM OLD.status THEN
+    NEW.status_updated_at := now();
+  END IF;
+  NEW.updated_at := now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_showing_requests_updated ON showing_requests;
+CREATE TRIGGER trg_showing_requests_updated
+BEFORE UPDATE ON showing_requests
+FOR EACH ROW EXECUTE PROCEDURE set_status_updated_at();


### PR DESCRIPTION
## Summary
- document running database migrations
- include SQL to add admin workflow columns and trigger

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68422cd2b94c8326b87d55f49d7084ce