### PR TITLE
Add error boundary for property request form

### DIFF
--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+
+interface ErrorBoundaryProps {
+  children: React.ReactNode;
+  fallback?: React.ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+}
+
+class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: unknown) {
+    console.error("ErrorBoundary caught an error", error);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return this.props.fallback ?? <div>Something went wrong.</div>;
+    }
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/src/pages/BuyerDashboard.tsx
+++ b/src/pages/BuyerDashboard.tsx
@@ -6,6 +6,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Calendar, Clock, MapPin, Phone, User, Plus, CheckCircle, AlertCircle, Star, ArrowRight } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
 import PropertyRequestForm from "@/components/PropertyRequestForm";
+import ErrorBoundary from "@/components/ErrorBoundary";
 import ShowingRequestCard from "@/components/dashboard/ShowingRequestCard";
 import { Link, useNavigate } from "react-router-dom";
 import { useAuth } from "@/contexts/AuthContext";
@@ -507,10 +508,12 @@ const BuyerDashboard = () => {
         </Tabs>
       </div>
 
-      <PropertyRequestForm 
-        isOpen={showPropertyForm}
-        onClose={() => setShowPropertyForm(false)}
-      />
+      <ErrorBoundary>
+        <PropertyRequestForm
+          isOpen={showPropertyForm}
+          onClose={() => setShowPropertyForm(false)}
+        />
+      </ErrorBoundary>
     </div>
   );
 };

--- a/src/pages/DCBuyers.tsx
+++ b/src/pages/DCBuyers.tsx
@@ -1,6 +1,7 @@
 
 import { useState } from "react";
 import PropertyRequestForm from "@/components/PropertyRequestForm";
+import ErrorBoundary from "@/components/ErrorBoundary";
 import HeroSection from "@/components/dc-buyers/HeroSection";
 import TrustIndicators from "@/components/dc-buyers/TrustIndicators";
 import ProblemSolutionSection from "@/components/dc-buyers/ProblemSolutionSection";
@@ -44,10 +45,12 @@ const DCBuyers = () => {
       <FinalCTASection onRequestShowing={handleRequestShowing} onSignUp={handleSignUp} />
 
       {/* Property Request Form Modal */}
-      <PropertyRequestForm 
-        isOpen={showPropertyForm}
-        onClose={() => setShowPropertyForm(false)}
-      />
+      <ErrorBoundary>
+        <PropertyRequestForm
+          isOpen={showPropertyForm}
+          onClose={() => setShowPropertyForm(false)}
+        />
+      </ErrorBoundary>
     </div>
   );
 };

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 import { useAuth } from "@/contexts/AuthContext";
 import { useNavigate } from "react-router-dom";
 import PropertyRequestForm from "@/components/PropertyRequestForm";
+import ErrorBoundary from "@/components/ErrorBoundary";
 import HowItWorks from "@/components/HowItWorks";
 import TrustIndicators from "@/components/TrustIndicators";
 import ProblemSolutionSection from "@/components/ProblemSolutionSection";
@@ -61,10 +62,12 @@ const Index = () => {
       <FAQSection />
       <FinalCTASection onRequestShowing={handleRequestShowing} />
 
-      <PropertyRequestForm 
-        isOpen={showPropertyForm}
-        onClose={() => setShowPropertyForm(false)}
-      />
+      <ErrorBoundary>
+        <PropertyRequestForm
+          isOpen={showPropertyForm}
+          onClose={() => setShowPropertyForm(false)}
+        />
+      </ErrorBoundary>
 
       <footer className="bg-slate-800 text-white py-8">
         <div className="container mx-auto px-4 text-center">

--- a/src/pages/Subscriptions.tsx
+++ b/src/pages/Subscriptions.tsx
@@ -5,6 +5,7 @@ import { Badge } from "@/components/ui/badge";
 import { Check, Star, Phone, Shield, Users, ArrowRight, Sparkles, Zap, Home } from "lucide-react";
 import { Link } from "react-router-dom";
 import PropertyRequestForm from "@/components/PropertyRequestForm";
+import ErrorBoundary from "@/components/ErrorBoundary";
 
 const Subscriptions = () => {
   const [showAuthModal, setShowAuthModal] = useState(false);
@@ -424,10 +425,12 @@ const Subscriptions = () => {
         </div>
       </div>
 
-      <PropertyRequestForm 
-        isOpen={showPropertyForm} 
-        onClose={() => setShowPropertyForm(false)} 
-      />
+      <ErrorBoundary>
+        <PropertyRequestForm
+          isOpen={showPropertyForm}
+          onClose={() => setShowPropertyForm(false)}
+        />
+      </ErrorBoundary>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- prevent uncaught errors from crashing the app by wrapping `PropertyRequestForm` with a new `ErrorBoundary` component
- update pages to use the boundary

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684247e3e154832698e8636d4fccf5b6