### PR TITLE
Fix CTA on DC buyers page

### DIFF
--- a/src/pages/DCBuyers.tsx
+++ b/src/pages/DCBuyers.tsx
@@ -35,7 +35,7 @@ const DCBuyers = () => {
       </div>
 
       {/* Main Content Sections */}
-      <ProblemSolutionSection />
+      <ProblemSolutionSection onRequestShowing={handleRequestShowing} />
       <BenefitsSection onSignUp={handleSignUp} />
       <HowItWorksSection />
       <NeighborhoodsSection />


### PR DESCRIPTION
## Summary
- pass `onRequestShowing` to DC buyers problem/solution section so CTA triggers the property request modal

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684250ffac388326b322642dac5d708e