### PR TITLE
Fix useAssignShowingRequest import path

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test": "vitest run"
+    "test": "npx vitest run"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",

--- a/src/hooks/useShowingRequests.ts
+++ b/src/hooks/useShowingRequests.ts
@@ -1,0 +1,1 @@
+export { useAssignShowingRequest } from './useAssignShowingRequest';


### PR DESCRIPTION
## Summary
- expose `useAssignShowingRequest` through the old `useShowingRequests.ts` path to keep compatibility
- run tests using `npx vitest`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684253f9270883268e3dde876ea9aeec