### PR TITLE
Improve login routing and protect dashboards

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
+import ProtectedRoute from "@/components/routes/ProtectedRoute";
 import { AuthProvider } from "@/contexts/AuthContext";
 import Navigation from "@/components/Navigation";
 import Index from "./pages/Index";
@@ -37,9 +38,30 @@ const App = () => (
               <Route path="/" element={<Index />} />
               <Route path="/faq" element={<FAQ />} />
               <Route path="/agents" element={<AgentLanding />} />
-              <Route path="/buyer-dashboard" element={<BuyerDashboard />} />
-              <Route path="/agent-dashboard" element={<AgentDashboard />} />
-              <Route path="/admin-dashboard" element={<AdminDashboard />} />
+              <Route
+                path="/buyer-dashboard"
+                element={
+                  <ProtectedRoute allowedRoles={["buyer"]}>
+                    <BuyerDashboard />
+                  </ProtectedRoute>
+                }
+              />
+              <Route
+                path="/agent-dashboard"
+                element={
+                  <ProtectedRoute allowedRoles={["agent"]}>
+                    <AgentDashboard />
+                  </ProtectedRoute>
+                }
+              />
+              <Route
+                path="/admin-dashboard"
+                element={
+                  <ProtectedRoute allowedRoles={["admin"]}>
+                    <AdminDashboard />
+                  </ProtectedRoute>
+                }
+              />
               <Route path="/subscriptions" element={<Subscriptions />} />
               <Route path="/blog" element={<Blog />} />
               <Route path="/blog/:slug" element={<BlogPost />} />

--- a/src/components/routes/ProtectedRoute.tsx
+++ b/src/components/routes/ProtectedRoute.tsx
@@ -1,0 +1,32 @@
+import { useAuth } from "@/contexts/AuthContext";
+import { Navigate } from "react-router-dom";
+
+interface ProtectedRouteProps {
+  children: JSX.Element;
+  allowedRoles: string[];
+}
+
+const ProtectedRoute = ({ children, allowedRoles }: ProtectedRouteProps) => {
+  const { user, loading } = useAuth();
+
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        Loading...
+      </div>
+    );
+  }
+
+  if (!user) {
+    return <Navigate to="/buyer-auth?tab=login" replace />;
+  }
+
+  const userType = user.user_metadata?.user_type as string | undefined;
+  if (!userType || !allowedRoles.includes(userType)) {
+    return <Navigate to="/" replace />;
+  }
+
+  return children;
+};
+
+export default ProtectedRoute;

--- a/src/hooks/useAuthForm.tsx
+++ b/src/hooks/useAuthForm.tsx
@@ -2,6 +2,7 @@
 import { useState } from "react";
 import { useToastHelper } from "@/utils/toastUtils";
 import { useAuth } from "@/contexts/AuthContext";
+import { supabase } from "@/integrations/supabase/client";
 
 interface AuthFormData {
   email: string;
@@ -62,10 +63,19 @@ export const useAuthForm = (
           toastHelper.error("Error", error.message);
         } else {
           toastHelper.success("Success!", "Welcome back!");
+          // Fetch the authenticated user to determine their role
+          const { data } = await supabase.auth.getUser();
+          const type =
+            (data.user?.user_metadata?.user_type as string | undefined) ??
+            userType;
           onSuccess();
-          if (userType === 'buyer') {
-            window.location.href = '/buyer-dashboard';
-          }
+          const redirect =
+            type === "agent"
+              ? "/agent-dashboard"
+              : type === "admin"
+              ? "/admin-dashboard"
+              : "/buyer-dashboard";
+          window.location.href = redirect;
         }
       } else {
         // Use the password from the form instead of generating one


### PR DESCRIPTION
## Summary
- ensure login redirect respects actual user role
- add ProtectedRoute component for role checks
- protect dashboard routes using `ProtectedRoute`

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684347b2372c8326a0644d51ee0f6677