### PR TITLE
Fix page refresh routing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@ import { Toaster } from "@/components/ui/toaster";
 import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { HashRouter, Routes, Route } from "react-router-dom";
 import ProtectedRoute from "@/components/routes/ProtectedRoute";
 import { AuthProvider } from "@/contexts/AuthContext";
 import Navigation from "@/components/Navigation";
@@ -31,7 +31,7 @@ const App = () => (
       <TooltipProvider>
         <Toaster />
         <Sonner />
-        <BrowserRouter>
+        <HashRouter>
           <div className="min-h-screen bg-gradient-to-br from-slate-50 via-purple-50 to-blue-50">
             <Navigation />
             <Routes>
@@ -73,7 +73,7 @@ const App = () => (
               <Route path="*" element={<NotFound />} />
             </Routes>
           </div>
-        </BrowserRouter>
+        </HashRouter>
       </TooltipProvider>
     </AuthProvider>
   </QueryClientProvider>


### PR DESCRIPTION
## Summary
- use `HashRouter` instead of `BrowserRouter` to avoid 404 errors when refreshing client‑side routes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68435386cd7c8326bd0a6ebb4f06cf6d