### PR TITLE
Document status values and validate updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,19 @@ status migration:
 supabase db execute < supabase/sql/20250615_update_status_check.sql
 ```
 
+The allowed values for the `status` column are:
+
+```
+pending
+submitted
+under_review
+agent_assigned
+confirmed
+scheduled
+completed
+cancelled
+```
+
 ## Can I connect a custom domain to my Lovable project?
 
 Yes, you can!

--- a/src/hooks/useAdminDashboard.ts
+++ b/src/hooks/useAdminDashboard.ts
@@ -3,6 +3,7 @@ import { useState, useEffect } from "react";
 import { useAuth } from "@/contexts/AuthContext";
 import { supabase } from "@/integrations/supabase/client";
 import { useToast } from "@/hooks/use-toast";
+import { isValidShowingStatus } from "@/utils/showingStatus";
 import { useNavigate } from "react-router-dom";
 
 interface Profile {
@@ -87,6 +88,13 @@ export const useAdminDashboard = () => {
   };
 
   const assignToAgent = async (requestId: string, agent: Profile) => {
+    const newStatus = "agent_assigned";
+
+    if (!isValidShowingStatus(newStatus)) {
+      toast({ title: "Error", description: "Invalid status", variant: "destructive" });
+      return;
+    }
+
     const { error } = await supabase
       .from("showing_requests")
       .update({
@@ -94,7 +102,7 @@ export const useAdminDashboard = () => {
         assigned_agent_name: `${agent.first_name} ${agent.last_name}`,
         assigned_agent_phone: agent.phone,
         assigned_agent_email: null,
-        status: "agent_assigned",
+        status: newStatus,
         status_updated_at: new Date().toISOString(),
       })
       .eq("id", requestId);
@@ -112,6 +120,11 @@ export const useAdminDashboard = () => {
     newStatus: string,
     estimatedDate?: string
   ) => {
+    if (!isValidShowingStatus(newStatus)) {
+      toast({ title: "Error", description: "Invalid status", variant: "destructive" });
+      return false;
+    }
+
     const updates: ShowingRequestUpdates = {
       status: newStatus,
       status_updated_at: new Date().toISOString(),

--- a/src/utils/showingStatus.ts
+++ b/src/utils/showingStatus.ts
@@ -1,13 +1,27 @@
 
-export type ShowingStatus = 
-  | 'submitted' 
-  | 'under_review' 
-  | 'agent_assigned' 
-  | 'confirmed' 
-  | 'scheduled' 
-  | 'completed' 
-  | 'cancelled' 
+export type ShowingStatus =
+  | 'submitted'
+  | 'under_review'
+  | 'agent_assigned'
+  | 'confirmed'
+  | 'scheduled'
+  | 'completed'
+  | 'cancelled'
   | 'pending'; // legacy status
+
+export const SHOWING_STATUS_VALUES: readonly ShowingStatus[] = [
+  'pending',
+  'submitted',
+  'under_review',
+  'agent_assigned',
+  'confirmed',
+  'scheduled',
+  'completed',
+  'cancelled'
+];
+
+export const isValidShowingStatus = (value: string): value is ShowingStatus =>
+  SHOWING_STATUS_VALUES.includes(value as ShowingStatus);
 
 export interface StatusInfo {
   label: string;


### PR DESCRIPTION
## Summary
- list allowed `showing_requests.status` values in README
- expose allowed statuses and validation helpers
- validate status updates in the admin dashboard

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68436232497c8326a600faf9b67a5434