### PR TITLE
Fix tour request redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,10 +82,10 @@ Simply open [Lovable](https://lovable.dev/projects/df1616ad-5732-43de-9096-ccd1e
 
 ## Running tests
 
-Install dependencies if you haven't already:
+Install dependencies if you haven't already. This ensures `vitest` and the ESLint configuration are available:
 
 ```sh
-npm ci
+npm install
 ```
 
 If you encounter errors running `npm run lint` or `npm test`, double-check that

--- a/src/hooks/usePropertyRequest.tsx
+++ b/src/hooks/usePropertyRequest.tsx
@@ -173,12 +173,18 @@ export const usePropertyRequest = () => {
         description: `Your showing request${propertiesToSubmit.length > 1 ? 's have' : ' has'} been submitted. We'll review and assign a showing partner within 2-4 hours.`,
       });
 
-      // Navigate to dashboard based on user type
-      navigate(
+      // Redirect to the appropriate dashboard. Using a full page reload
+      // ensures the latest requests are fetched even if the user
+      // is already on their dashboard.
+      const redirectPath =
         user.user_metadata?.user_type === 'agent'
           ? '/agent-dashboard'
-          : '/buyer-dashboard'
-      );
+          : '/buyer-dashboard';
+
+      // React Router's navigate won't reload the page if we're already on
+      // the dashboard. Using window.location.href guarantees the dashboard
+      // refreshes and shows the new request immediately.
+      window.location.href = redirectPath;
       
     } catch (error) {
       console.error('Error submitting showing requests:', error);


### PR DESCRIPTION
## Summary
- ensure buyer dashboard reloads after submitting tour requests
- clarify README instructions for running tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6843895f560483268428bc661acdaa15