### PR TITLE
Improve handling of outdated status constraint

### DIFF
--- a/src/hooks/useAssignShowingRequest.ts
+++ b/src/hooks/useAssignShowingRequest.ts
@@ -60,10 +60,17 @@ export const useAssignShowingRequest = () => {
 
       if (error) {
         console.error('Error assigning request:', error.message, error.details, error.hint);
-        toastHelper.error(
-          "Assignment Failed",
-          `Database error: ${error.message}${error.details ? ` - ${error.details}` : ''}`
-        );
+        if (error.message?.includes('showing_requests_status_check')) {
+          toastHelper.error(
+            'Assignment Failed',
+            'Database schema outdated. Run `supabase db execute < supabase/sql/20250615_update_status_check.sql` to allow new statuses.'
+          );
+        } else {
+          toastHelper.error(
+            'Assignment Failed',
+            `Database error: ${error.message}${error.details ? ` - ${error.details}` : ''}`
+          );
+        }
         return false;
       }
 


### PR DESCRIPTION
## Summary
- give clearer feedback when assignment fails due to outdated `showing_requests_status_check`

## Testing
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68438fac21348326aee19d1b501948b0