### PR TITLE
Implement admin approval flow with notifications

### DIFF
--- a/src/components/dashboard/AdminRequestCard.tsx
+++ b/src/components/dashboard/AdminRequestCard.tsx
@@ -40,9 +40,10 @@ interface AdminRequestCardProps {
   agents: AgentProfile[];
   onAssign: (requestId: string, agent: AgentProfile) => void;
   onUpdateStatus: (status: string) => void;
+  onApprove?: (requestId: string) => void;
 }
 
-const AdminRequestCard = ({ request, agents, onAssign, onUpdateStatus }: AdminRequestCardProps) => {
+const AdminRequestCard = ({ request, agents, onAssign, onUpdateStatus, onApprove }: AdminRequestCardProps) => {
   const statusInfo = getStatusInfo(request.status as ShowingStatus);
   const timeline = getEstimatedTimeline(request.status as ShowingStatus);
 
@@ -118,6 +119,9 @@ const AdminRequestCard = ({ request, agents, onAssign, onUpdateStatus }: AdminRe
           </div>
         </div>
         <div className="flex gap-3 items-center">
+          {request.status === 'pending_admin_approval' && onApprove && (
+            <Button onClick={() => onApprove(request.id)}>Approve</Button>
+          )}
           {!request.assigned_agent_name && (
             <Select onValueChange={(value) => {
               const agent = agents.find((a) => a.id === value);

--- a/src/hooks/useAdminDashboard.ts
+++ b/src/hooks/useAdminDashboard.ts
@@ -147,6 +147,28 @@ export const useAdminDashboard = () => {
     return true;
   };
 
+  const approveShowingRequest = async (requestId: string) => {
+    const newStatus = 'confirmed';
+    const { error } = await supabase
+      .from('showing_requests')
+      .update({
+        status: newStatus,
+        status_updated_at: new Date().toISOString(),
+      })
+      .eq('id', requestId);
+
+    if (error) {
+      toast({ title: 'Error', description: 'Failed to approve request', variant: 'destructive' });
+    } else {
+      toast({ title: 'Approved', description: 'Showing request approved.' });
+      fetchAdminData();
+      // Call notification function
+      await supabase.functions.invoke('notify-agent', {
+        body: { requestId },
+      });
+    }
+  };
+
   useEffect(() => {
     if (authLoading) return;
     if (!user && !session) {
@@ -157,5 +179,5 @@ export const useAdminDashboard = () => {
     fetchAdminData();
   }, [user, session, authLoading, navigate]);
 
-  return { showingRequests, agents, loading, assignToAgent, handleStatusUpdate };
+  return { showingRequests, agents, loading, assignToAgent, handleStatusUpdate, approveShowingRequest };
 };

--- a/src/hooks/useBuyerDashboard.ts
+++ b/src/hooks/useBuyerDashboard.ts
@@ -214,11 +214,24 @@ export const useBuyerDashboard = () => {
   };
 
   const handleAgreementSign = async (name: string) => {
-    if (!selectedShowing) return;
-    
-    toast({ title: 'Confirmed', description: 'Your showing has been confirmed.' });
+    if (!selectedShowing || !user) return;
+
+    const { error } = await supabase.from('tour_agreements').insert({
+        showing_request_id: selectedShowing.id,
+        agent_id: selectedShowing.assigned_agent_id,
+        buyer_id: user.id,
+        signed: true,
+        signed_at: new Date().toISOString()
+    });
+
+    if (error) {
+        toast({ title: 'Error', description: 'Failed to save agreement.', variant: 'destructive' });
+        return;
+    }
+
+    toast({ title: 'Confirmed', description: 'Your showing has been confirmed and agreement signed.' });
     setAgreements(prev => ({ ...prev, [selectedShowing.id]: true }));
-    
+
     setSelectedShowing(null);
   };
 

--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -12,10 +12,11 @@ const AdminDashboard = () => {
   const [selectedRequest, setSelectedRequest] = useState<ShowingRequest | null>(null);
   const [showStatusModal, setShowStatusModal] = useState(false);
 
-  const { showingRequests, agents, loading, assignToAgent, handleStatusUpdate } = useAdminDashboard();
+  const { showingRequests, agents, loading, assignToAgent, handleStatusUpdate, approveShowingRequest } = useAdminDashboard();
 
   const unassigned = showingRequests.filter((r) => canBeAssigned(r.status as ShowingStatus) && !r.assigned_agent_name);
   const active = showingRequests.filter((r) => isActiveShowing(r.status as ShowingStatus));
+  const pendingApproval = showingRequests.filter((r) => r.status === 'pending_admin_approval');
 
   const handleUpdateStatus = async (id: string, newStatus: string, estimated?: string) => {
     const success = await handleStatusUpdate(id, newStatus, estimated);
@@ -44,9 +45,10 @@ const AdminDashboard = () => {
       </div>
       <div className="container mx-auto px-4 py-8">
         <Tabs defaultValue="all" className="space-y-6">
-          <TabsList className="grid w-full grid-cols-3">
+          <TabsList className="grid w-full grid-cols-4">
             <TabsTrigger value="all">All ({showingRequests.length})</TabsTrigger>
             <TabsTrigger value="unassigned">Unassigned ({unassigned.length})</TabsTrigger>
+            <TabsTrigger value="pending_approval">Pending Approval ({pendingApproval.length})</TabsTrigger>
             <TabsTrigger value="active">Active ({active.length})</TabsTrigger>
           </TabsList>
           <TabsContent value="all" className="space-y-6">
@@ -82,6 +84,21 @@ const AdminDashboard = () => {
                 />
               ))
             )}
+          </TabsContent>
+          <TabsContent value="pending_approval" className="space-y-6">
+            {pendingApproval.map((req) => (
+              <AdminRequestCard
+                key={req.id}
+                request={req}
+                agents={agents}
+                onAssign={assignToAgent}
+                onApprove={approveShowingRequest}
+                onUpdateStatus={() => {
+                  setSelectedRequest(req);
+                  setShowStatusModal(true);
+                }}
+              />
+            ))}
           </TabsContent>
           <TabsContent value="active" className="space-y-6">
             {active.length === 0 ? (

--- a/src/pages/AgentDashboard.tsx
+++ b/src/pages/AgentDashboard.tsx
@@ -13,6 +13,7 @@ import { useAgentDashboard } from "@/hooks/useAgentDashboard";
 import { isActiveShowing, canBeAssigned, isPendingRequest, type ShowingStatus } from "@/utils/showingStatus";
 
 const AgentDashboard = () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const [selectedRequest, setSelectedRequest] = useState<any>(null);
   const [showStatusModal, setShowStatusModal] = useState(false);
   // const [showMessageModal, setShowMessageModal] = useState(false);
@@ -48,7 +49,7 @@ const AgentDashboard = () => {
   };
 
   const handleAcceptShowing = async (requestId: string) => {
-    await handleStatusUpdate(requestId, 'scheduled');
+    await handleStatusUpdate(requestId, 'pending_admin_approval');
   };
 
   // Organize requests by categories
@@ -56,8 +57,8 @@ const AgentDashboard = () => {
     canBeAssigned(req.status as ShowingStatus) && !req.assigned_agent_name
   );
   
-  const myRequests = showingRequests.filter(req => 
-    profile && req.assigned_agent_email === (profile as any).email
+  const myRequests = showingRequests.filter(
+    req => profile && req.assigned_agent_email === (profile as { email?: string }).email
   );
   
   const activeShowings = showingRequests.filter(req => 

--- a/src/pages/BuyerDashboard.tsx
+++ b/src/pages/BuyerDashboard.tsx
@@ -38,6 +38,7 @@ const BuyerDashboard = () => {
     setShowPropertyForm(true);
   };
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const handleConfirmShowingWithModal = (showing: any) => {
     handleConfirmShowing(showing);
     setShowAgreementModal(true);

--- a/src/utils/showingStatus.ts
+++ b/src/utils/showingStatus.ts
@@ -3,6 +3,7 @@ export type ShowingStatus =
   | 'submitted'
   | 'under_review'
   | 'agent_assigned'
+  | 'pending_admin_approval'
   | 'confirmed'
   | 'scheduled'
   | 'completed'
@@ -14,6 +15,7 @@ export const SHOWING_STATUS_VALUES: readonly ShowingStatus[] = [
   'submitted',
   'under_review',
   'agent_assigned',
+  'pending_admin_approval',
   'confirmed',
   'scheduled',
   'completed',
@@ -56,6 +58,14 @@ export const getStatusInfo = (status: ShowingStatus): StatusInfo => {
       color: 'text-purple-800',
       bgColor: 'bg-purple-100',
       icon: '👤',
+      isActive: false
+    },
+    pending_admin_approval: {
+      label: 'Pending Admin Approval',
+      description: 'The agent has accepted, awaiting final approval from admin.',
+      color: 'text-yellow-800',
+      bgColor: 'bg-yellow-100',
+      icon: '⏳',
       isActive: false
     },
     confirmed: {
@@ -108,6 +118,7 @@ export const getEstimatedTimeline = (status: ShowingStatus): string => {
     submitted: 'We typically respond within 2-4 hours',
     under_review: 'Agent assignment usually takes 4-8 hours',
     agent_assigned: 'Your agent will contact you within 2 hours',
+    pending_admin_approval: 'Awaiting final admin approval',
     confirmed: 'All set! See you at the showing',
     scheduled: 'All set! See you at the showing',
     completed: 'Thank you for using FirstLook!',

--- a/supabase/functions/notify-agent/index.ts
+++ b/supabase/functions/notify-agent/index.ts
@@ -1,0 +1,53 @@
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import sgMail from "https://esm.sh/@sendgrid/mail@7.7.0";
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+};
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  try {
+    const { requestId } = await req.json();
+    if (!requestId) {
+      return new Response(JSON.stringify({ error: 'requestId required' }), { headers: { ...corsHeaders, 'Content-Type': 'application/json' }, status: 400 });
+    }
+
+    const supabaseUrl = Deno.env.get('SUPABASE_URL');
+    const supabaseKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
+    const sendgridKey = Deno.env.get('SENDGRID_API_KEY');
+    const fromEmail = Deno.env.get('FROM_EMAIL');
+
+    if (!supabaseUrl || !supabaseKey || !sendgridKey || !fromEmail) {
+      return new Response(JSON.stringify({ error: 'Missing environment configuration' }), { headers: { ...corsHeaders, 'Content-Type': 'application/json' }, status: 500 });
+    }
+
+    const client = createClient(supabaseUrl, supabaseKey);
+    const { data, error } = await client
+      .from('showing_requests')
+      .select('assigned_agent_email, property_address')
+      .eq('id', requestId)
+      .single();
+
+    if (error || !data) {
+      return new Response(JSON.stringify({ error: 'Request not found' }), { headers: { ...corsHeaders, 'Content-Type': 'application/json' }, status: 404 });
+    }
+
+    sgMail.setApiKey(sendgridKey);
+    await sgMail.send({
+      to: data.assigned_agent_email,
+      from: fromEmail,
+      subject: 'Showing Request Approved',
+      text: `Your showing request for ${data.property_address} has been approved.`,
+    });
+
+    return new Response(JSON.stringify({ success: true }), { headers: { ...corsHeaders, 'Content-Type': 'application/json' }, status: 200 });
+  } catch (e) {
+    return new Response(JSON.stringify({ error: 'Unexpected error' }), { headers: { ...corsHeaders, 'Content-Type': 'application/json' }, status: 500 });
+  }
+});

--- a/supabase/sql/20250615_update_status_check.sql
+++ b/supabase/sql/20250615_update_status_check.sql
@@ -9,6 +9,7 @@ ALTER TABLE showing_requests
       'submitted',
       'under_review',
       'agent_assigned',
+      'pending_admin_approval',
       'confirmed',
       'scheduled',
       'completed',


### PR DESCRIPTION
## Summary
- support `pending_admin_approval` status
- update DB status constraint and enums
- allow agents to accept and move requests to pending approval
- let admins approve requests and trigger notification email
- show pending approval tab on admin dashboard
- enable buyers to save signed tour agreements
- add `notify-agent` function for sending approval emails

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6846da488ffc8326b19b2581a1499c7f