### PR TITLE
Fix signup detection

### DIFF
--- a/src/components/property-request/QuickSignInModal.tsx
+++ b/src/components/property-request/QuickSignInModal.tsx
@@ -105,7 +105,7 @@ const QuickSignInModal = ({
                 password={currentAuth.formData.password}
                 isLoading={currentAuth.isLoading}
                 onInputChange={currentAuth.handleInputChange}
-                onSubmit={currentAuth.handleSubmit}
+                onSubmit={(e) => currentAuth.handleSubmit(e, true)}
                 onSocialLogin={currentAuth.handleSocialLogin}
               />
             </TabsContent>
@@ -120,7 +120,7 @@ const QuickSignInModal = ({
                 licenseNumber={currentAuth.formData.licenseNumber}
                 isLoading={currentAuth.isLoading}
                 onInputChange={currentAuth.handleInputChange}
-                onSubmit={currentAuth.handleSubmit}
+                onSubmit={(e) => currentAuth.handleSubmit(e, false)}
                 onSocialLogin={currentAuth.handleSocialLogin}
               />
             </TabsContent>

--- a/src/hooks/useAuthForm.tsx
+++ b/src/hooks/useAuthForm.tsx
@@ -52,12 +52,16 @@ export const useAuthForm = (
     setFormData(prev => ({ ...prev, [field]: value }));
   };
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = async (
+    e: React.FormEvent,
+    loginMode?: boolean
+  ) => {
     e.preventDefault();
     setIsLoading(true);
 
     try {
-      if (isLogin) {
+      const isLoginMode = loginMode ?? isLogin;
+      if (isLoginMode) {
         const { error } = await signIn(formData.email, formData.password);
         if (error) {
           toastHelper.error("Error", error.message);

--- a/src/pages/AdminAuth.tsx
+++ b/src/pages/AdminAuth.tsx
@@ -61,10 +61,7 @@ const AdminAuth = () => {
                     licenseNumber={adminAuth.formData.licenseNumber}
                     isLoading={adminAuth.isLoading}
                     onInputChange={adminAuth.handleInputChange}
-                    onSubmit={(e) => {
-                      adminAuth.setIsLogin(false);
-                      adminAuth.handleSubmit(e);
-                    }}
+                    onSubmit={(e) => adminAuth.handleSubmit(e, false)}
                     onSocialLogin={adminAuth.handleSocialLogin}
                   />
                 </TabsContent>
@@ -74,10 +71,7 @@ const AdminAuth = () => {
                     password={adminAuth.formData.password}
                     isLoading={adminAuth.isLoading}
                     onInputChange={adminAuth.handleInputChange}
-                    onSubmit={(e) => {
-                      adminAuth.setIsLogin(true);
-                      adminAuth.handleSubmit(e);
-                    }}
+                    onSubmit={(e) => adminAuth.handleSubmit(e, true)}
                     onSocialLogin={adminAuth.handleSocialLogin}
                   />
                 </TabsContent>

--- a/src/pages/AgentAuth.tsx
+++ b/src/pages/AgentAuth.tsx
@@ -130,10 +130,7 @@ const AgentAuth = () => {
                     licenseNumber={agentAuth.formData.licenseNumber}
                     isLoading={agentAuth.isLoading}
                     onInputChange={agentAuth.handleInputChange}
-                    onSubmit={(e) => {
-                      agentAuth.setIsLogin(false);
-                      agentAuth.handleSubmit(e);
-                    }}
+                    onSubmit={(e) => agentAuth.handleSubmit(e, false)}
                     onSocialLogin={agentAuth.handleSocialLogin}
                   />
                 </TabsContent>
@@ -144,10 +141,7 @@ const AgentAuth = () => {
                     password={agentAuth.formData.password}
                     isLoading={agentAuth.isLoading}
                     onInputChange={agentAuth.handleInputChange}
-                    onSubmit={(e) => {
-                      agentAuth.setIsLogin(true);
-                      agentAuth.handleSubmit(e);
-                    }}
+                    onSubmit={(e) => agentAuth.handleSubmit(e, true)}
                     onSocialLogin={agentAuth.handleSocialLogin}
                   />
                 </TabsContent>

--- a/src/pages/BuyerAuth.tsx
+++ b/src/pages/BuyerAuth.tsx
@@ -135,10 +135,7 @@ const BuyerAuth = () => {
                     licenseNumber={buyerAuth.formData.licenseNumber}
                     isLoading={buyerAuth.isLoading}
                     onInputChange={buyerAuth.handleInputChange}
-                    onSubmit={(e) => {
-                      buyerAuth.setIsLogin(false);
-                      buyerAuth.handleSubmit(e);
-                    }}
+                    onSubmit={(e) => buyerAuth.handleSubmit(e, false)}
                     onSocialLogin={buyerAuth.handleSocialLogin}
                   />
                 </TabsContent>
@@ -149,10 +146,7 @@ const BuyerAuth = () => {
                     password={buyerAuth.formData.password}
                     isLoading={buyerAuth.isLoading}
                     onInputChange={buyerAuth.handleInputChange}
-                    onSubmit={(e) => {
-                      buyerAuth.setIsLogin(true);
-                      buyerAuth.handleSubmit(e);
-                    }}
+                    onSubmit={(e) => buyerAuth.handleSubmit(e, true)}
                     onSocialLogin={buyerAuth.handleSocialLogin}
                   />
                 </TabsContent>


### PR DESCRIPTION
## Summary
- avoid stale `isLogin` state by passing explicit mode to submit handler
- update buyer/agent/admin pages and quick login modal
- allow sign up on first try

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68473d44e62c8326babdb63daab49b9b